### PR TITLE
#11 Feat: 면접 진행 페이지 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.90.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-separator':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -501,6 +504,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
@@ -625,6 +637,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1972,6 +1997,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -2104,6 +2135,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:

--- a/src/components/interview/InterviewHeader.tsx
+++ b/src/components/interview/InterviewHeader.tsx
@@ -1,0 +1,23 @@
+import { Button } from '../ui/button';
+import { Progress } from '../ui/progress';
+import { DoorOpenIcon } from 'lucide-react';
+
+export default function InterviewHeader() {
+  return (
+    <header className="flex items-center justify-between border-b bg-muted px-8 py-4">
+      <div className="flex items-center gap-2">
+        <span className="text-sub2">진행도</span>
+        <Progress value={10} className="w-40" />
+        <span className="text-sub2">1 / 10</span>
+      </div>
+      <Button
+        className="hover:text-destructive [&_svg]:!size-8"
+        variant="ghost"
+        size="icon"
+        aria-label="나가기"
+      >
+        <DoorOpenIcon />
+      </Button>
+    </header>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { TimerIcon, PlayIcon } from 'lucide-react';
+import InterviewHeader from '@/components/interview/InterviewHeader';
+
+export default function InterviewPage() {
+  return (
+    <div>
+      <InterviewHeader />
+
+      <div className="mx-auto max-w-5xl px-10 py-6">
+        <Card className="mb-6">
+          <CardContent className="flex items-center gap-2 p-5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-full border bg-muted text-sub1 font-semibold">
+              1
+            </span>
+            <span className="text-sub1 font-semibold">
+              자기소개를 해주세요.
+            </span>
+            <Badge variant="secondary">기본</Badge>
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-3 gap-6">
+          <Card className="col-span-2 h-[320px]">
+            <CardContent className="relative h-full p-0">
+              <div className="flex h-full items-center justify-center">
+                에이바 영역
+              </div>
+              <div className="absolute bottom-4 right-4 flex items-center gap-2 rounded-lg bg-muted px-3 py-1 shadow">
+                <TimerIcon className="h-5 w-5" />
+                01 : 30
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="h-[320px]">
+            <CardContent className="flex h-full items-center justify-center p-0">
+              사용자 얼굴 영역
+            </CardContent>
+          </Card>
+
+          <Card className="col-span-2 h-[100px]">
+            <CardContent className="flex h-full items-center justify-center p-0">
+              내 답변 영역
+            </CardContent>
+          </Card>
+
+          <Card className="h-[100px]">
+            <CardContent className="flex h-full items-center justify-center p-0">
+              목소리 파동 영역
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="mt-8 flex justify-center gap-4">
+          <Button size="lg">
+            <PlayIcon className="h-6 w-6" />
+            답변 시작
+          </Button>
+          <Button variant="outline">꼬리 질문</Button>
+          <Button variant="outline">다음 질문</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -28,4 +28,12 @@ export const router = createBrowserRouter([
       },
     ],
   },
+
+  {
+    path: 'interview',
+    lazy: async () => {
+      const { default: InterviewPage } = await import('@/pages/InterviewPage');
+      return { element: <InterviewPage /> };
+    },
+  },
 ]);


### PR DESCRIPTION
✅ #11 Feat: 면접 진행 페이지 UI 구현

## 1. 개발 내용
- 면접 진행 페이지 라우팅 설정
- 면접 진행 페이지 UI 구현

## 2. 구현 세부사항
<img width="1508" height="947" alt="image" src="https://github.com/user-attachments/assets/ed398285-6edb-457c-9cc6-1cda4a963f96" />

## 3. 메모
- Shadcn `Progress` `Badge` 컴포넌트 추가했습니다.
- 우선 해당 화면에 쓰일 헤더 컴포넌트만 분리해놨습니다. 나머지는 기능 구현 때 분리 예정 ..
- 면접 시작 모달은 얘기 좀 더 나눠봐야 할 것 같아서 이것도 확정되면 진행하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interview page with progress tracking during the interview flow.
  * Integrated interview UI including sections for user feedback, video display, and voice visualization.
  * Added action buttons to start responses and navigate between questions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->