### PR TITLE
#35 Fix:qa 적용

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,12 +1,19 @@
 import logo from '@/assets/images/logo.svg';
 
-export default function Loader() {
+interface Props {
+  message?: string;
+}
+
+export default function Loader({ message }: Props) {
   return (
-    <div className="flex h-screen w-screen flex-col items-center justify-center">
+    <div className="flex h-screen w-screen flex-col items-center justify-center gap-4">
       <div className="flex animate-bounce items-center gap-2">
         <img className="h-10 w-10" src={logo} alt="박면준 로고 이미지" />
         <div className="text-h3 font-bold">bakmyunjun</div>
       </div>
+      {message && (
+        <p className="text-sm text-muted-foreground">{message}</p>
+      )}
     </div>
   );
 }

--- a/src/components/home/InterviewRecordItem.tsx
+++ b/src/components/home/InterviewRecordItem.tsx
@@ -7,22 +7,34 @@ interface Props {
   record: InterviewRecord;
 }
 
+const MAX_TAGS = 2;
+
 export function InterviewRecordItem({ record }: Props) {
+  const visibleStrengths = record.strengths.slice(0, MAX_TAGS);
+  const visibleImprovements = record.improvements.slice(0, MAX_TAGS);
+  const hiddenCount =
+    record.strengths.length +
+    record.improvements.length -
+    visibleStrengths.length -
+    visibleImprovements.length;
+
   return (
     <Link to={`/report/${record.interviewId}`}>
       <Card className="p-6 transition-colors hover:bg-muted/50">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 flex-1 items-center gap-4">
             {/* 점수 */}
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 text-lg font-bold text-amber-600">
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-100 text-lg font-bold text-amber-600">
               {Math.round(record.score)}
             </div>
 
             {/* 정보 */}
-            <div>
+            <div className="min-w-0">
               <div className="flex items-center gap-2">
-                <p className="font-semibold">{record.title || record.date}</p>
-                <span className="text-sm text-muted-foreground">
+                <p className="truncate font-semibold">
+                  {record.title || record.date}
+                </p>
+                <span className="shrink-0 text-sm text-muted-foreground">
                   {record.duration}
                 </span>
               </div>
@@ -33,26 +45,31 @@ export function InterviewRecordItem({ record }: Props) {
           </div>
 
           {/* 강점/개선점 태그 */}
-          <div className="flex items-center gap-4">
-            <div className="flex flex-wrap gap-1">
-              {record.strengths.map((strength) => (
+          <div className="flex shrink-0 items-center gap-4">
+            <div className="flex max-w-[280px] flex-wrap justify-end gap-1">
+              {visibleStrengths.map((strength) => (
                 <span
                   key={strength}
-                  className="rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700"
+                  className="truncate rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700"
                 >
                   {strength}
                 </span>
               ))}
-              {record.improvements.map((improvement) => (
+              {visibleImprovements.map((improvement) => (
                 <span
                   key={improvement}
-                  className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700"
+                  className="truncate rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700"
                 >
                   {improvement}
                 </span>
               ))}
+              {hiddenCount > 0 && (
+                <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                  +{hiddenCount}
+                </span>
+              )}
             </div>
-            <ChevronRight className="h-5 w-5 text-muted-foreground" />
+            <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" />
           </div>
         </div>
       </Card>

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -58,7 +58,7 @@ export default function InterviewPage() {
         });
         setTimeout(() => {
           navigate('/');
-        }, 3000);
+        }, 4000);
         return;
       }
 

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -37,6 +37,7 @@ export default function InterviewPage() {
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(true);
   const [answerStatus, setAnswerStatus] = useState<AnswerStatus>('READY');
   const [timeLeft, setTimeLeft] = useState(INITIAL_TIME);
+  const [isCompleted, setIsCompleted] = useState(false);
 
   const {
     answerText,
@@ -51,10 +52,13 @@ export default function InterviewPage() {
   const { mutate: submitTurn, isPending: isSubmitTurnPending } = useSubmitTurn({
     onSuccess: () => {
       if (isLastTurn) {
+        setIsCompleted(true);
         toast.success('수고하셨습니다!', {
           description: '면접 결과를 확인해보세요.',
         });
-        navigate(`/report/${interviewInfo?.interviewId}`);
+        setTimeout(() => {
+          navigate('/');
+        }, 3000);
         return;
       }
 
@@ -147,6 +151,10 @@ export default function InterviewPage() {
 
   if (!interviewInfo) {
     return <Loader />;
+  }
+
+  if (isCompleted) {
+    return <Loader message="면접 결과를 분석 중입니다..." />;
   }
 
   return (


### PR DESCRIPTION
## 1. 개발 내용
- 면접 종료시 4초후 홈으로 이동
- 면접 기록 ui 수정
## 2. 구현 세부사항
<img width="681" height="432" alt="image" src="https://github.com/user-attachments/assets/5230b7b8-9926-4d96-be7c-825476280aa3" />

## 3. 메모


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로더 컴포넌트에 메시지 표시 기능 추가
  * 인터뷰 완료 후 결과 분석 상태 화면 추가

* **UI 개선**
  * 인터뷰 기록 항목의 태그 표시 최적화 및 숨겨진 항목에 "+N" 표시 추가
  * 레이아웃 및 콘텐츠 절단 개선으로 사용자 인터페이스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->